### PR TITLE
Narrative report table sync issue addressed.

### DIFF
--- a/ETL_v2.php
+++ b/ETL_v2.php
@@ -289,10 +289,13 @@ foreach ($tablesMap as $dest_table => $source_table)
                         }
                     }
                     if (!empty($mappedTimestampColumn)) {
+                        //parsing of last record is required in case it is an object (e.g. narrative_report)
+                        $lastRecord = (!is_array($rs_array[count($rs_array) - 1])) ?
+                            (array)$rs_array[count($rs_array) - 1] : $rs_array[count($rs_array) - 1];
                         $rdsLastModifiedTimestamp[$dest_table] = date_format(
                             date_create_from_format(
                                 'Y-m-d H:i:s',
-                                $rs_array[count($rs_array) - 1][$mappedTimestampColumn] ?? date('Y-m-d H:i:s')
+                                $lastRecord[$mappedTimestampColumn] ?? date('Y-m-d H:i:s')
                             ),
                             'Y-m-d H:i:s'
                         ) // date from last record - FM_extract converts it to 'Y-m-d H:i:s' while mapping and returning
@@ -322,10 +325,13 @@ foreach ($tablesMap as $dest_table => $source_table)
                         }
                     }
                     if (!empty($mappedTimestampColumn)) {
+                        //parsing of last record is required in case it is an object (e.g. narrative_report)
+                        $lastRecord = (!is_array($rs_array[count($rs_array) - 1])) ?
+                            (array)$rs_array[count($rs_array) - 1] : $rs_array[count($rs_array) - 1];
                         $snowLastModifiedTimestamp[$dest_table] = date_format(
                             date_create_from_format(
                                 'Y-m-d H:i:s',
-                                $rs_array[count($rs_array) - 1][$mappedTimestampColumn] ?? date('Y-m-d H:i:s')
+                                $lastRecord[$mappedTimestampColumn] ?? date('Y-m-d H:i:s')
                             ),
                             'Y-m-d H:i:s'
                         ) // date from last record - FM_extract converts it to 'Y-m-d H:i:s' while mapping and returning
@@ -415,10 +421,13 @@ foreach ($tablesMap as $dest_table => $source_table)
                             }
                         }
                         if (!empty($mappedTimestampColumn)) {
+                            //parsing of last record is required in case it is an object (e.g. narrative_report)
+                            $lastRecord = (!is_array($rs_array[count($rs_array) - 1])) ?
+                                (array)$rs_array[count($rs_array) - 1] : $rs_array[count($rs_array) - 1];
                             $rdsLastModifiedTimestamp[$dest_table] = date_format(
                                 date_create_from_format(
                                     'Y-m-d H:i:s',
-                                    $rs_array[count($rs_array) - 1][$mappedTimestampColumn] ?? date('Y-m-d H:i:s')
+                                    $lastRecord[$mappedTimestampColumn] ?? date('Y-m-d H:i:s')
                                 ),
                                 'Y-m-d H:i:s'
                             ) // date from last record - FM_extract converts it to 'Y-m-d H:i:s' while mapping and returning
@@ -494,10 +503,13 @@ foreach ($tablesMap as $dest_table => $source_table)
                             }
                         }
                         if (!empty($mappedTimestampColumn)) {
+                            //parsing of last record is required in case it is an object (e.g. narrative_report)
+                            $lastRecord = (!is_array($rs_array[count($rs_array) - 1])) ?
+                                (array)$rs_array[count($rs_array) - 1] : $rs_array[count($rs_array) - 1];
                             $snowLastModifiedTimestamp[$dest_table] = date_format(
                                 date_create_from_format(
                                     'Y-m-d H:i:s',
-                                    $rs_array[count($rs_array) - 1][$mappedTimestampColumn] ?? date('Y-m-d H:i:s')
+                                    $lastRecord[$mappedTimestampColumn] ?? date('Y-m-d H:i:s')
                                 ),
                                 'Y-m-d H:i:s'
                             ) // date from last record - FM_extract converts it to 'Y-m-d H:i:s' while mapping and returning

--- a/config/sourceSearchQueries.php
+++ b/config/sourceSearchQueries.php
@@ -33,18 +33,20 @@ return [
         ['modificationHostTimestamp' => DATETIME_SEARCH_PLACEHOLDER]
        ],
     'narrative_report' => [
-        ['modificationHostTimestamp' => DATETIME_SEARCH_PLACEHOLDER]
+        ['creationHostTimestamp' => DATETIME_SEARCH_PLACEHOLDER]
        ],
     'therapist' => [
         ['modificationHostTimestamp' => DATETIME_SEARCH_PLACEHOLDER, 'type' => '=therapist'],
         ['nameFull' => "=", 'omit' => 'true']
     ],
     'users' => [
-        ['modificationHostTimestamp' => DATETIME_SEARCH_PLACEHOLDER, 'type' => '=user'],
-        ['nameFull' => "=", 'omit' => 'true']
+        // ['modificationHostTimestamp' => DATETIME_SEARCH_PLACEHOLDER, 'subtype' => '=user'],
+        // ['modificationHostTimestamp' => DATETIME_SEARCH_PLACEHOLDER, 'subtype' => '=DME'],
+        // ['nameFull' => "=", 'omit' => 'true']
+        ['modificationHostTimestamp' => DATETIME_SEARCH_PLACEHOLDER, 'active' => '=1'],
     ],
     'reviewer' => [
-        ['modificationHostTimestamp' => DATETIME_SEARCH_PLACEHOLDER, 'type' => '=reviewer'],
+        ['modificationHostTimestamp' => DATETIME_SEARCH_PLACEHOLDER, 'reviewer' => '=1'],
         ['nameFull' => "=", 'omit' => 'true']
     ],
     'therapy_networks' => [

--- a/config/validTimestampColumns.php
+++ b/config/validTimestampColumns.php
@@ -2,5 +2,6 @@
 
 return [
     'modificationHostTimestamp',
+    'creationHostTimestamp',
     'timestamp'
 ];


### PR DESCRIPTION
- Fixed: Records were being stored as objects instead of arrays in case of narrative_report table
- Fixed: SourceSearchQueries updated against destination tables.
- Added: Added creationHostTimestamp as validTimestampColumns